### PR TITLE
Cf accept encoding bug

### DIFF
--- a/src/Concerns/BuildClient.php
+++ b/src/Concerns/BuildClient.php
@@ -12,6 +12,7 @@ trait BuildClient
         return Http::baseUrl($this->baseUrl)
             ->withHeaders([
                 'Accept' => 'application/json',
+                'Accept-Encoding' => 'identity',
             ]);
     }
 }


### PR DESCRIPTION
Since Sportmonks migrated to Cloudflare, the HTTP client has stopped recognizing the encoding header. This is due to Cloudflare using the custom X-Encoded-Content-Encoding header, which Guzzle HTTP fails to identify for automatic decompression.